### PR TITLE
execute commands as database users in a login shell

### DIFF
--- a/dbdump/libdump/backend.py
+++ b/dbdump/libdump/backend.py
@@ -33,7 +33,7 @@ class backend(object):
 
     def make_su(self, cmd):
         if 'su' in self.section:
-            cmd = ['su', self.section['su'], '-s',
+            cmd = ['su', '-', self.section['su'], '-s',
                    '/bin/bash', '-c', ' '.join(cmd)]
         return cmd
 


### PR DESCRIPTION
It fixes 'could not change directory to "/root": Permission denied'.
This happens if dbdump runs as root and uses 'su'. The database-dump-program then tries to run with /root as working directory without having execute-permission for /root.
