### PR TITLE
Silence/Fix: DeprecationWarning in dbdump.py

### DIFF
--- a/dbdump/dbdump.py
+++ b/dbdump/dbdump.py
@@ -49,7 +49,7 @@ args = parser.parse_args()
 if args.section == 'DEFAULT':
     parser.error("--section must not be 'DEFAULT'.")
 
-config = configparser.SafeConfigParser({
+config = configparser.ConfigParser({
     'format': '%%Y-%%m-%%d_%%H:%%M:%%S',
     'datadir': '/var/backups/%(backend)s',
     'mysql-ignore-tables': '',


### PR DESCRIPTION
Silence/Fix: ``DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.``